### PR TITLE
Fix le RRule.between bug #3,401

### DIFF
--- a/src/RRule.elm
+++ b/src/RRule.elm
@@ -326,38 +326,6 @@ hasCount rrule =
             False
 
 
-
-{- Window
-
-   TODO Helps ???
--}
-
-
-initWindow : Posix -> RRule -> Window
-initWindow lowerBound rrule =
-    { lowerBound = lowerBound
-    , upperBound =
-        TE.ceiling (windowInterval rrule) rrule.tzid lowerBound
-            |> Util.subtract 1
-    }
-
-
-windowInterval : RRule -> TE.Interval
-windowInterval rrule =
-    case rrule.frequency of
-        Daily ->
-            TE.Day
-
-        Weekly ->
-            Util.weekdayToInterval rrule.weekStart
-
-        Monthly ->
-            TE.Month
-
-        Yearly ->
-            TE.Year
-
-
 withinRuleset : RRule -> Posix -> Bool
 withinRuleset rrule time =
     withinByRules rrule time
@@ -818,6 +786,31 @@ The same is true for other frequencies. We skip off-days, off-months, and off-ye
 -}
 type alias Window =
     { lowerBound : Posix, upperBound : Posix }
+
+
+initWindow : Posix -> RRule -> Window
+initWindow lowerBound rrule =
+    { lowerBound = lowerBound
+    , upperBound =
+        TE.ceiling (windowInterval rrule) rrule.tzid lowerBound
+            |> Util.subtract 1
+    }
+
+
+windowInterval : RRule -> TE.Interval
+windowInterval rrule =
+    case rrule.frequency of
+        Daily ->
+            TE.Day
+
+        Weekly ->
+            Util.weekdayToInterval rrule.weekStart
+
+        Monthly ->
+            TE.Month
+
+        Yearly ->
+            TE.Year
 
 
 {-| -}

--- a/src/RRule.elm
+++ b/src/RRule.elm
@@ -1,4 +1,14 @@
-module RRule exposing (Error(..), Frequency(..), RRule, UntilCount(..), all, between, errorToString, fromStrings, fromStringsWithStart)
+module RRule exposing
+    ( Error(..)
+    , Frequency(..)
+    , RRule
+    , UntilCount(..)
+    , all
+    , between
+    , errorToString
+    , fromStrings
+    , fromStringsWithStart
+    )
 
 import Date exposing (Date, Month)
 import Dict

--- a/src/RRule.elm
+++ b/src/RRule.elm
@@ -1178,16 +1178,6 @@ parseDateToParts =
         |= P.succeed 0
 
 
-{-| "20190806"
--}
-parseDate : Parser Date
-parseDate =
-    P.succeed Date.fromCalendarDate
-        |= chompDigits 4
-        |= (chompDigits 2 |> P.map Date.numberToMonth)
-        |= chompDigits 2
-
-
 parseNegatableInt : Parser Int
 parseNegatableInt =
     P.oneOf

--- a/src/RRule.elm
+++ b/src/RRule.elm
@@ -23,16 +23,13 @@ import Util
 
 {-| -}
 type alias RRule =
-    { -- Required
-      frequency : Frequency
+    { frequency : Frequency
     , weekStart : Weekday
     , interval : Int
     , dtStart : Posix
 
     -- TODO Support floating times by having the user provide a fallback IANA / Zone?
     , tzid : Zone
-
-    -- Optional
     , untilCount : Maybe UntilCount
     , byDay : List (Either ( Int, Weekday ) Weekday)
     , byMonthDay : List Int
@@ -41,12 +38,6 @@ type alias RRule =
     , byYearDay : List Int
     , exdates : List Posix
     , rdates : List Posix
-
-    -- Currently not supported
-    --, bySecond : List Int
-    --, byMinute : List Int
-    --, byHour : List Int
-    --, bySetPos : List Int
     }
 
 

--- a/src/RRule.elm
+++ b/src/RRule.elm
@@ -72,7 +72,12 @@ between ({ start, end } as betweenWindow) preNormalizedRRule =
                 Util.year2250
 
         runHelp { firstInstanceTime, startingWindow } =
-            run ceiling rrule startingWindow firstInstanceTime []
+            run (hasNoExpands preNormalizedRRule)
+                ceiling
+                rrule
+                startingWindow
+                firstInstanceTime
+                []
     in
     if hasCount rrule then
         {- We just naively run any RRULE with a COUNT and filter
@@ -98,7 +103,7 @@ all preNormalizedRRule =
         rrule =
             normalizeRRule preNormalizedRRule
     in
-    run (hasNoExpands rrule)
+    run (hasNoExpands preNormalizedRRule)
         Util.year2250
         rrule
         (initWindow rrule.dtStart rrule)
@@ -114,18 +119,13 @@ run rruleHasNoExpands timeCeiling rrule window current acc =
 
         nextTime =
             if rruleHasNoExpands then
-                -- If there are no expanding BYRULES we can confidently jump right
-                -- to the next time using the rrule's frequency (e.g. daily, weekly, yearly)
-                -- TODO Will this rarely/ever get called because of how we normalize the rrule?
+                -- The vast majority of these will be YEARLY events, e.g. birthdays.
                 TE.add (freqToInterval rrule.frequency)
                     rrule.interval
                     rrule.tzid
                     current
 
             else if inWindow nextByDay window then
-                -- If there are expanding BYRULES we need to check each day within
-                -- the window. TODO Finish comment
-                --
                 -- TODO check to see if this behaving correctly by adding tests
                 -- for rrule's with RULE:FREQ=WEEKLY;BYDAY=SA,SU,MO;WEEKSTART=SU and MO;
                 nextByDay

--- a/src/RRule.elm
+++ b/src/RRule.elm
@@ -158,6 +158,9 @@ run rruleHasNoExpands timeCeiling rrule window current acc =
             |> withoutExDates
 
     else if current |> withinRuleset rrule then
+        {- Note: DO NOT partially apply `run` in the `let` statement above.
+           We need to keep the full call to `run` down here for tail-call optimization.
+        -}
         run rruleHasNoExpands timeCeiling rrule nextWindow nextTime (current :: acc)
 
     else

--- a/tests/Examples/Between.elm
+++ b/tests/Examples/Between.elm
@@ -294,3 +294,89 @@ example9 =
         }
     , dates = [ 1225807200000, 1352210400000, 1478613600000, 1604412000000 ]
     }
+
+
+example10 : Example
+example10 =
+    { description = "window.start is an off-day of an every-fifth-day event"
+    , rrule =
+        [ "DTSTART;TZID=America/Denver:20201215T090000"
+        , "RRULE:FREQ=DAILY;INTERVAL=5"
+        ]
+    , recurrence =
+        { defaultRules
+            | dtStart = Time.millisToPosix 1608048000000
+            , frequency = Daily
+            , interval = 5
+        }
+    , window =
+        { start = (Time.millisToPosix 1608220800000 {- 2020-12-17T16:00:00.000Z -})
+        , end = (Time.millisToPosix 1613577600000 {- 2021-02-17T16:00:00.000Z -})
+        }
+    , dates = [ 1608480000000, 1608912000000, 1609344000000, 1609776000000, 1610208000000, 1610640000000, 1611072000000, 1611504000000, 1611936000000, 1612368000000, 1612800000000, 1613232000000 ]
+    }
+
+
+example11 : Example
+example11 =
+    { description = "window.start is an off-week of a tuesday-every-third-week event"
+    , rrule =
+        [ "DTSTART;TZID=America/Denver:20201215T090000"
+        , "RRULE:FREQ=WEEKLY;INTERVAL=3"
+        ]
+    , recurrence =
+        { defaultRules
+            | dtStart = Time.millisToPosix 1608048000000
+            , frequency = Weekly
+            , interval = 3
+        }
+    , window =
+        { start = (Time.millisToPosix 1608566400000 {- 2020-12-21T16:00:00.000Z -})
+        , end = (Time.millisToPosix 1615132800000 {- 2021-03-07T16:00:00.000Z -})
+        }
+    , dates = [ 1609862400000, 1611676800000, 1613491200000 ]
+    }
+
+
+example12 : Example
+example12 =
+    { description = "window.start is an off-month of an every-other-month event"
+    , rrule =
+        [ "DTSTART;TZID=America/Chicago:20180703T170000"
+        , "RRULE:FREQ=MONTHLY;INTERVAL=2;BYDAY=1TU"
+        ]
+    , recurrence =
+        { defaultRules
+            | dtStart = Time.millisToPosix 1530655200000
+            , frequency = Monthly
+            , interval = 2
+            , byDay = [ Left ( 1, Tue ) ]
+            , tzid = TimeZone.america__chicago ()
+        }
+    , window =
+        { start = (Time.millisToPosix 1550886858009 {- 2019-02-23T01:54:18.009Z -})
+        , end = (Time.millisToPosix 1644198858009 {- 2022-02-07T01:54:18.009Z -})
+        }
+    , dates = [ 1551826800000, 1557266400000, 1562104800000, 1567548000000, 1572994800000, 1578438000000, 1583276400000, 1588716000000, 1594159200000, 1598997600000, 1604444400000, 1609887600000, 1614726000000, 1620165600000, 1625608800000, 1631052000000, 1635890400000, 1641337200000 ]
+    }
+
+
+example13 : Example
+example13 =
+    { description = "window.start in an off-year of an every-ten-year event"
+    , rrule =
+        [ "DTSTART;TZID=America/Denver:20201215T090000"
+        , "RRULE:FREQ=YEARLY;INTERVAL=10"
+        ]
+    , recurrence =
+        { defaultRules
+            | dtStart = Time.millisToPosix 1608048000000
+            , frequency = Yearly
+            , interval = 10
+        }
+    , window =
+        { start = (Time.millisToPosix 1609804800000 {- 2021-01-05T00:00:00.000Z -})
+        , end = (Time.millisToPosix 1923609600000 {- 2030-12-16T00:00:00.000Z -})
+        }
+    , dates = [ 1923580800000 ]
+    }

--- a/tests/Examples/Custom.elm
+++ b/tests/Examples/Custom.elm
@@ -149,3 +149,20 @@ example6 =
         }
     , dates = [ 1591164000000, 1591768800000, 1592373600000, 1592978400000, 1593583200000, 1594188000000, 1594792800000, 1595397600000, 1596002400000, 1596607200000, 1597212000000, 1597816800000 ]
     }
+
+
+{-| Le birthday
+-}
+example7 =
+    { description = "Infer the day/month in a yearly event. No byrules."
+    , rrule =
+        [ "DTSTART;TZID=America/Denver:19870701T000000"
+        , "RRULE:FREQ=YEARLY;COUNT=3"
+        ]
+    , recurrence =
+        { defaultRules
+            | untilCount = Just (Count 3)
+            , dtStart = Time.millisToPosix 552117600000
+        }
+    , dates = [ 552117600000, 583740000000, 615276000000 ]
+    }

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -80,6 +80,7 @@ custom =
         , Custom.example4
         , Custom.example5
         , Custom.example6
+        , Custom.example7
         ]
 
 
@@ -97,6 +98,10 @@ suite =
         , Between.example8_2
         , Between.example8_3
         , Between.example9
+        , Between.example10
+        , Between.example11
+        , Between.example12
+        , Between.example13
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -80,6 +80,7 @@ custom =
         , Custom.example4
         , Custom.example5
         , Custom.example6
+        , Custom.example7
         ]
 
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -80,7 +80,6 @@ custom =
         , Custom.example4
         , Custom.example5
         , Custom.example6
-        , Custom.example7
         ]
 
 

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -52,7 +52,7 @@ const all = (rrules, mTimeZone) =>
 
 const between = (rrules, mTimeZone) => (windowStart, windowEnd) => {
     // Yes, this `setZone` and `toUTC` business looks confusing.
-    // rrule.js has some shit API decisions for handling timezones.
+    // rrule.js has some unusual API decisions for handling timezones.
     // See https://github.com/jakubroztocil/rrule#important-use-utc-dates
     const [start, end] = [
         toUTC(windowStart),


### PR DESCRIPTION
Fix "betweenWindow.start is an off-N of an every-Y-N event" bug.
Add tests for each frequency to instill confidence.

E.g. If betweenWindow.start sits in an off-month of an every-3-months recurring event, the `betweenStartTimeHelper` was not finding the first instance properly.

Also, fix `normalizeRRule` for Yearly events.